### PR TITLE
Failing test

### DIFF
--- a/src/test/scala/es/weso/ShexValidatorSpec.scala
+++ b/src/test/scala/es/weso/ShexValidatorSpec.scala
@@ -1,0 +1,39 @@
+package es.weso
+
+import es.weso.rdf.rdf4j.RDFAsRDF4jModel
+import es.weso.shapeMaps.ShapeMap
+import es.weso.shex.Schema
+import es.weso.shex.validator.Validator
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.io.Source
+
+class ShexValidatorSpec extends FlatSpec with Matchers  {
+  "The Shex Validator" should "validate triples, given the mappings and the shex definition" in {
+    val rdfContent            = Source.fromFile("examples/user.ttl")
+    val shexDefinition      = Source.fromFile("examples/user.shex")
+    val mappingsDeclaration = Source.fromFile("examples/user.sm")
+
+    val validation = for {
+      rdf  <- RDFAsRDF4jModel.fromChars(rdfContent.getLines.mkString, "TURTLE", None)
+      shex <- Schema.fromString(shexDefinition.getLines.mkString, "ShexC")
+      shapeMap <- ShapeMap.fromString(mappingsDeclaration.getLines().mkString,
+                                      ShapeMap.defaultFormat,
+                                      None,
+                                      rdf.getPrefixMap(),
+                                      shex.prefixMap)
+      fixedShapeMap <- ShapeMap.fixShapeMap(shapeMap, rdf, rdf.getPrefixMap, shex.prefixMap)
+      result        <- Validator.validate(shex, fixedShapeMap, rdf)
+    } yield result
+
+    validation match {
+      case Right(result) =>
+        result.noSolutions should be (false)
+
+      case Left(e) =>
+        fail(e)
+    }
+
+  }
+
+}


### PR DESCRIPTION
Hi, 

   Adding the test in this PR makes it to fail because of a hardcoded path somewhere I'm not able to spot. 

I get:

```
$ sbt test
[info] Loading settings for project global-plugins from plugins.sbt ...
[info] Loading global plugins from /Users/cebriant/.sbt/1.0/plugins
[info] Loading settings for project simpleshexscala-build from plugins.sbt ...
[info] Loading project definition from /Users/cebriant/forked_repos/simpleShExScala/project
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] Loading settings for project simpleShExScala from version.sbt,build.sbt ...
[info] Set current project to simpleShExScala (in build file:/Users/cebriant/forked_repos/simpleShExScala/)
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] Compiling 2 Scala sources to /Users/cebriant/forked_repos/simpleShExScala/target/scala-2.13/classes ...
[info] Cleaning datadir [/Users/cebriant/forked_repos/simpleShExScala/target/scala-2.13/scoverage-data]
[info] Beginning coverage instrumentation
[info] Instrumentation completed [141 statements]
[info] Wrote instrumentation file [/Users/cebriant/forked_repos/simpleShExScala/target/scala-2.13/scoverage-data/scoverage.coverage]
[info] Will write measurement data to [/Users/cebriant/forked_repos/simpleShExScala/target/scala-2.13/scoverage-data]
[info] Compiling 1 Scala source to /Users/cebriant/forked_repos/simpleShExScala/target/scala-2.13/test-classes ...
[info] ShexValidatorSpec:
[info] The Shex Validator
[info] - should validate triples, given the mappings and the shex definition *** FAILED ***
[info]   java.io.FileNotFoundException: /home/labra/src/shapes/utils/modules/utils/target/scala-2.13/scoverage-data/scoverage.measurements.23 (No such file or directory)
[info]   at java.base/java.io.FileOutputStream.open0(Native Method)
[info]   at java.base/java.io.FileOutputStream.open(FileOutputStream.java:292)
[info]   at java.base/java.io.FileOutputStream.<init>(FileOutputStream.java:235)
[info]   at java.base/java.io.FileWriter.<init>(FileWriter.java:113)
[info]   at scoverage.Invoker$.$anonfun$invoked$1(Invoker.scala:55)
[info]   at scala.collection.mutable.HashMap.getOrElseUpdate(HashMap.scala:384)
[info]   at scoverage.Invoker$.invoked(Invoker.scala:55)
[info]   at es.weso.utils.StrUtils$.unescapeIRI(StrUtils.scala:30)
[info]   at es.weso.shex.compact.SchemaMaker.extractIRIfromIRIREF(SchemaMaker.scala:658)
[info]   at es.weso.shex.compact.SchemaMaker.visitPrefixDecl(SchemaMaker.scala:1349)
[info]   ...
[info] Run completed in 2 seconds, 86 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 0, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
[error] Failed tests:
[error] 	es.weso.ShexValidatorSpec
[error] (Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 9 s, completed Dec 2, 2019, 12:15:04 PM
```