### PR TITLE
BUG: Bumping libraries to latest version breaks the example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ lazy val simpleShExScala = project
   .in(file("."))
   .settings(
     libraryDependencies ++= Seq(
-      "es.weso"           %% "shex"          % "0.1.52",
-      "es.weso"           %% "srdf4j"        % "0.1.54",
+      "es.weso"           %% "shex"          % "0.1.59",
+      "es.weso"           %% "srdf4j"        % "0.1.66",
       "org.scalatest"     %% "scalatest"     % "3.1.0" % Test,
       "org.eclipse.rdf4j" % "rdf4j-rio-trig" % "3.0.4" % Test
     ),
@@ -16,6 +16,6 @@ lazy val simpleShExScala = project
     resolvers ++= Seq(
       Resolver.bintrayRepo("labra", "maven")
     ),
-    scalaVersion := "2.12.8",
+    scalaVersion := "2.13.2",
     fork := true
   )


### PR DESCRIPTION
Seems like backwards compatibility was broken. Could you fix the unit test so it works with latest libraries?